### PR TITLE
Adding a simple bootloader for arm64

### DIFF
--- a/arch/arm64/bootloader.S
+++ b/arch/arm64/bootloader.S
@@ -1,0 +1,5 @@
+.section .text
+.global _start
+
+_start:
+    b .   // Infinite loop (just halts the CPU for now)


### PR DESCRIPTION
Adding a simple bootloader written in Assembly for the arch64 architecture. We are using a .S extension to instruct the system to pass it through the C preprocessor (cpp) before sending it to the assembler so that we can use higher level functions such as macros, headers, and conditional compilation instructions. 

For now all we are instructing it to do is to enter into an infinite loop by calling ourselves as the branch to jump to. (b .)